### PR TITLE
Use relative URLs for internal navigation

### DIFF
--- a/about.html
+++ b/about.html
@@ -60,7 +60,7 @@
       </div>
     </div></section>
   </main>
-  <footer class="luxury-vignette"><div class="container footer-grid"><div><div class="brand">Baayno Bookbindery</div><p class="muted">Advanced bookbinding and high-end packaging since 1964.</p></div><div><strong>Company</strong><div class="stack-2 mt-4"><a href="about.html">About</a><a href="gallery.html">Gallery</a><a href="services.html">Services</a><a href="contact.html">Contact</a></div></div><div><strong>Legal</strong><div class="stack-2 mt-4"><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a></div></div></div><div class="container copyright">&copy; <span id="y"></span> Baayno Bookbindery.</div></footer>
+  <footer class="luxury-vignette"><div class="container footer-grid"><div><div class="brand">Baayno Bookbindery</div><p class="muted">Advanced bookbinding and high-end packaging since 1964.</p></div><div><strong>Company</strong><div class="stack-2 mt-4"><a href="about.html">About</a><a href="gallery.html">Gallery</a><a href="services.html">Services</a><a href="contact.html">Contact</a></div></div><div><strong>Legal</strong><div class="stack-2 mt-4"><a href="privacy.html">Privacy</a><a href="terms.html">Terms</a></div></div></div><div class="container copyright">&copy; <span id="y"></span> Baayno Bookbindery.</div></footer>
   <script type="module" src="assets/js/main.js"></script><script>document.getElementById('y').textContent = new Date().getFullYear()</script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -76,7 +76,7 @@
   <span class="inner">Send request</span>
 </button>
         <p class="form-message form-note" aria-live="polite"></p>
-        <p class="form-note">We respect your privacy. See our <a href="/privacy.html">Privacy Policy</a>.</p>
+        <p class="form-note">We respect your privacy. See our <a href="privacy.html">Privacy Policy</a>.</p>
       </form>
       <aside class="card">
         <h3>Bookbindery (Beirut)</h3>
@@ -94,7 +94,7 @@
     </div></section>
   </main>
   
-  <footer class="luxury-vignette"><div class="container footer-grid"><div><div class="brand">Baayno Bookbindery</div><p class="muted">Advanced bookbinding and high-end packaging since 1964.</p></div><div><strong>Company</strong><div class="stack-2 mt-4"><a href="about.html">About</a><a href="gallery.html">Gallery</a><a href="services.html">Services</a><a href="contact.html">Contact</a></div></div><div><strong>Legal</strong><div class="stack-2 mt-4"><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a></div></div></div><div class="container copyright">&copy; <span id="y"></span> Baayno Bookbindery.</div></footer>
+  <footer class="luxury-vignette"><div class="container footer-grid"><div><div class="brand">Baayno Bookbindery</div><p class="muted">Advanced bookbinding and high-end packaging since 1964.</p></div><div><strong>Company</strong><div class="stack-2 mt-4"><a href="about.html">About</a><a href="gallery.html">Gallery</a><a href="services.html">Services</a><a href="contact.html">Contact</a></div></div><div><strong>Legal</strong><div class="stack-2 mt-4"><a href="privacy.html">Privacy</a><a href="terms.html">Terms</a></div></div></div><div class="container copyright">&copy; <span id="y"></span> Baayno Bookbindery.</div></footer>
   <script type="module" src="assets/js/main.js"></script><script>document.getElementById('y').textContent = new Date().getFullYear()</script>
 </body>
 </html>

--- a/gallery.html
+++ b/gallery.html
@@ -96,7 +96,7 @@
       </div>
     </section>
   </main>
-  <footer class="luxury-vignette"><div class="container footer-grid"><div><div class="brand">Baayno Bookbindery</div><p class="muted">Advanced bookbinding and high-end packaging since 1964.</p></div><div><strong>Company</strong><div class="stack-2 mt-4"><a href="about.html">About</a><a href="gallery.html">Gallery</a><a href="services.html">Services</a><a href="contact.html">Contact</a></div></div><div><strong>Legal</strong><div class="stack-2 mt-4"><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a></div></div></div><div class="container copyright">&copy; <span id="y"></span> Baayno Bookbindery.</div></footer>
+  <footer class="luxury-vignette"><div class="container footer-grid"><div><div class="brand">Baayno Bookbindery</div><p class="muted">Advanced bookbinding and high-end packaging since 1964.</p></div><div><strong>Company</strong><div class="stack-2 mt-4"><a href="about.html">About</a><a href="gallery.html">Gallery</a><a href="services.html">Services</a><a href="contact.html">Contact</a></div></div><div><strong>Legal</strong><div class="stack-2 mt-4"><a href="privacy.html">Privacy</a><a href="terms.html">Terms</a></div></div></div><div class="container copyright">&copy; <span id="y"></span> Baayno Bookbindery.</div></footer>
   <script type="module" src="assets/js/main.js"></script><script>document.getElementById('y').textContent = new Date().getFullYear()</script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -310,8 +310,8 @@
       <div>
         <strong>Legal</strong>
         <div class="stack-2 mt-4">
-          <a href="/privacy.html">Privacy</a>
-          <a href="/terms.html">Terms</a>
+          <a href="privacy.html">Privacy</a>
+          <a href="terms.html">Terms</a>
         </div>
       </div>
     </div>

--- a/privacy.html
+++ b/privacy.html
@@ -7,10 +7,10 @@
   <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Playfair+Display:wght@600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/css/base.css" />
-  <link rel="canonical" href="https://www.baayno.com/privacy.html" />
+  <link rel="canonical" href="https://www.baayno.comprivacy.html" />
   <meta property="og:type" content="website" />
   <meta property="og:title" content="Privacy Policy &mdash; Fouad Baayno Bookbindery" />
-  <meta property="og:url" content="https://www.baayno.com/privacy.html" />
+  <meta property="og:url" content="https://www.baayno.comprivacy.html" />
   <script type="application/ld+json">{
     "@context":"https://schema.org",
     "@type":"WebPage",
@@ -46,7 +46,7 @@
       <p class="muted">Last updated: 2025-01-01</p>
     </div></section>
   </main>
-  <footer class="luxury-vignette"><div class="container footer-grid"><div><div class="brand">Baayno Bookbindery</div><p class="muted">Advanced bookbinding and high-end packaging since 1964.</p></div><div><strong>Company</strong><div class="stack-2 mt-4"><a href="about.html">About</a><a href="gallery.html">Gallery</a><a href="services.html">Services</a><a href="contact.html">Contact</a></div></div><div><strong>Legal</strong><div class="stack-2 mt-4"><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a></div></div></div><div class="container copyright">&copy; <span id="y"></span> Baayno Bookbindery.</div></footer>
+  <footer class="luxury-vignette"><div class="container footer-grid"><div><div class="brand">Baayno Bookbindery</div><p class="muted">Advanced bookbinding and high-end packaging since 1964.</p></div><div><strong>Company</strong><div class="stack-2 mt-4"><a href="about.html">About</a><a href="gallery.html">Gallery</a><a href="services.html">Services</a><a href="contact.html">Contact</a></div></div><div><strong>Legal</strong><div class="stack-2 mt-4"><a href="privacy.html">Privacy</a><a href="terms.html">Terms</a></div></div></div><div class="container copyright">&copy; <span id="y"></span> Baayno Bookbindery.</div></footer>
   <script type="module" src="assets/js/main.js"></script><script>document.getElementById('y').textContent = new Date().getFullYear()</script>
 </body>
 </html>

--- a/services.html
+++ b/services.html
@@ -125,7 +125,7 @@
       </div>
     </section>
   </main>
-  <footer class="luxury-vignette"><div class="container footer-grid"><div><div class="brand">Baayno Bookbindery</div><p class="muted">Advanced bookbinding and high-end packaging since 1964.</p></div><div><strong>Company</strong><div class="stack-2 mt-4"><a href="about.html">About</a><a href="gallery.html">Gallery</a><a href="services.html">Services</a><a href="contact.html">Contact</a></div></div><div><strong>Legal</strong><div class="stack-2 mt-4"><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a></div></div></div><div class="container copyright">&copy; <span id="y"></span> Baayno Bookbindery.</div></footer>
+  <footer class="luxury-vignette"><div class="container footer-grid"><div><div class="brand">Baayno Bookbindery</div><p class="muted">Advanced bookbinding and high-end packaging since 1964.</p></div><div><strong>Company</strong><div class="stack-2 mt-4"><a href="about.html">About</a><a href="gallery.html">Gallery</a><a href="services.html">Services</a><a href="contact.html">Contact</a></div></div><div><strong>Legal</strong><div class="stack-2 mt-4"><a href="privacy.html">Privacy</a><a href="terms.html">Terms</a></div></div></div><div class="container copyright">&copy; <span id="y"></span> Baayno Bookbindery.</div></footer>
   <script type="module" src="assets/js/main.js"></script><script>document.getElementById('y').textContent = new Date().getFullYear()</script>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -7,10 +7,10 @@
   <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Playfair+Display:wght@600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/css/base.css" />
-  <link rel="canonical" href="https://www.baayno.com/terms.html" />
+  <link rel="canonical" href="https://www.baayno.comterms.html" />
   <meta property="og:type" content="website" />
   <meta property="og:title" content="Terms of Service &mdash; Fouad Baayno Bookbindery" />
-  <meta property="og:url" content="https://www.baayno.com/terms.html" />
+  <meta property="og:url" content="https://www.baayno.comterms.html" />
   <script type="application/ld+json">{
     "@context":"https://schema.org",
     "@type":"WebPage",
@@ -43,7 +43,7 @@
       <p class="muted">Last updated: 2025-01-01</p>
     </div></section>
   </main>
-  <footer class="luxury-vignette"><div class="container footer-grid"><div><div class="brand">Baayno Bookbindery</div><p class="muted">Advanced bookbinding and high-end packaging since 1964.</p></div><div><strong>Company</strong><div class="stack-2 mt-4"><a href="about.html">About</a><a href="gallery.html">Gallery</a><a href="services.html">Services</a><a href="contact.html">Contact</a></div></div><div><strong>Legal</strong><div class="stack-2 mt-4"><a href="/privacy.html">Privacy</a><a href="/terms.html">Terms</a></div></div></div><div class="container copyright">&copy; <span id="y"></span> Baayno Bookbindery.</div></footer>
+  <footer class="luxury-vignette"><div class="container footer-grid"><div><div class="brand">Baayno Bookbindery</div><p class="muted">Advanced bookbinding and high-end packaging since 1964.</p></div><div><strong>Company</strong><div class="stack-2 mt-4"><a href="about.html">About</a><a href="gallery.html">Gallery</a><a href="services.html">Services</a><a href="contact.html">Contact</a></div></div><div><strong>Legal</strong><div class="stack-2 mt-4"><a href="privacy.html">Privacy</a><a href="terms.html">Terms</a></div></div></div><div class="container copyright">&copy; <span id="y"></span> Baayno Bookbindery.</div></footer>
   <script type="module" src="assets/js/main.js"></script><script>document.getElementById('y').textContent = new Date().getFullYear()</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Remove leading slashes from internal links so pages reference `privacy.html` and `terms.html` relative to current directory.
- Update contact page privacy note to use relative link.

## Testing
- `rg 'href="/' *.html`
- `python3 -m http.server 8000 &` + `npx linkinator http://localhost:8000/Baayno/index.html --recurse --skip "https://.*" --skip ".*assets.*" --silent`


------
https://chatgpt.com/codex/tasks/task_b_68c125e16a20832eb4d9838d4d0f13ca