### PR TITLE
Add base styles for site layout

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1,4 +1,308 @@
+/* Base styles */
 body {
   margin: 0;
   font-family: Arial, sans-serif;
+}
+
+/* Layout and utilities */
+.container {
+  width: 90%;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+.grid {
+  display: grid;
+  gap: 1.5rem;
+}
+.grid-2 {
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+}
+.grid-3 {
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+.gallery-grid,
+.services-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+.services-list {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+.stack-2 {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+.center {
+  text-align: center;
+}
+.cluster {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+.hide {
+  display: none;
+}
+.mt-4 {
+  margin-top: 1rem;
+}
+.mt-6 {
+  margin-top: 1.5rem;
+}
+.max-w-65ch {
+  max-width: 65ch;
+}
+.proof-chips {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+.chip,
+.chip-proof {
+  padding: 0.25rem 0.5rem;
+  background: #eee;
+  border-radius: 3px;
+  font-size: 0.875rem;
+}
+
+/* Navigation */
+.site-header {
+  background: #fff;
+  border-bottom: 1px solid #e5e5e5;
+}
+.nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 0;
+}
+.brand {
+  font-weight: bold;
+  font-size: 1.25rem;
+}
+.nav-links {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+.nav-links a {
+  text-decoration: none;
+  color: #333;
+}
+.nav-cta {
+  margin-left: 1rem;
+}
+.back-to-top {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+}
+
+/* Hero */
+.hero {
+  padding: 4rem 0;
+  text-align: center;
+}
+.hero-grid {
+  display: grid;
+  gap: 2rem;
+  align-items: center;
+}
+.hero-sub {
+  color: #666;
+  margin-top: 0.5rem;
+}
+.hero-cta {
+  margin-top: 1.5rem;
+}
+.scroll-hint {
+  margin-top: 2rem;
+  animation: bounce 2s infinite;
+}
+
+/* Buttons */
+.btn,
+.btn-quote,
+.btn-primary,
+.btn-ghost {
+  display: inline-block;
+  padding: 0.75rem 1.25rem;
+  border-radius: 4px;
+  text-decoration: none;
+}
+.btn-primary {
+  background: #007bff;
+  color: #fff;
+}
+.btn-ghost {
+  border: 1px solid #007bff;
+  color: #007bff;
+  background: transparent;
+}
+.btn-quote {
+  background: #333;
+  color: #fff;
+}
+.btn.with-arrow .arrow {
+  margin-left: 0.5rem;
+}
+.with-arrow {
+  display: inline-flex;
+  align-items: center;
+}
+.with-arrow .arrow {
+  transition: transform 0.3s;
+}
+.with-arrow:hover .arrow {
+  transform: translateX(4px);
+}
+
+/* Typography */
+.section-title {
+  font-size: 2rem;
+  margin: 2rem 0 1rem;
+}
+.eyebrow {
+  text-transform: uppercase;
+  font-size: 0.875rem;
+  color: #999;
+  letter-spacing: 0.1em;
+}
+.muted {
+  color: #666;
+}
+.link-accent {
+  color: #007bff;
+  text-decoration: underline;
+}
+.lbl {
+  display: block;
+  margin-top: 0.5rem;
+}
+.prose {
+  line-height: 1.6;
+}
+
+/* Content */
+.card {
+  padding: 1.5rem;
+  border: 1px solid #e5e5e5;
+  border-radius: 4px;
+  background: #fff;
+}
+.thumb,
+.svc-thumb {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+.svc-card {
+  text-align: center;
+}
+.svc-icon {
+  width: 40px;
+  height: 40px;
+  display: block;
+  margin: 0 auto 0.5rem;
+}
+.page-header {
+  padding: 2rem 0;
+  text-align: center;
+}
+.luxury-bg {
+  background: linear-gradient(135deg, #e0d6c5, #f5f5f5);
+}
+.luxury-vignette {
+  background: #111;
+  color: #fff;
+  padding: 2rem 0;
+}
+.points_wrapper {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  gap: 0.5rem;
+}
+.point {
+  background: #f5f5f5;
+  padding: 0.5rem;
+  border-radius: 2px;
+}
+.inner {
+  position: relative;
+}
+.icon-books {
+  font-size: 2rem;
+}
+.b1,
+.b2 {
+  display: block;
+}
+.footer-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+.copyright {
+  text-align: center;
+  font-size: 0.875rem;
+  margin-top: 2rem;
+}
+
+/* Forms and embeds */
+.map-embed {
+  width: 100%;
+  height: 300px;
+  border: 0;
+}
+.form-note,
+.form-message {
+  font-size: 0.875rem;
+}
+.form-message {
+  padding: 1rem;
+  background: #f5f5f5;
+  border-left: 4px solid #007bff;
+}
+.hp-field {
+  display: none;
+}
+.sm {
+  font-size: 0.875rem;
+}
+
+/* Services orbit */
+.services-orbit,
+.orbit-wrap,
+.ring,
+.node-wrap,
+.svc-node {
+  position: relative;
+}
+.ring {
+  border: 1px solid #ccc;
+  border-radius: 50%;
+}
+.node-wrap {
+  position: absolute;
+}
+
+/* Misc */
+.arrow {
+  display: inline-block;
+}
+
+@keyframes bounce {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-5px);
+  }
 }


### PR DESCRIPTION
## Summary
- implement navigation, hero, button, and layout utilities in base stylesheet
- add grid helpers and luxury background styles to match HTML classes

## Testing
- `npm test`
- `npx stylelint assets/css/base.css` *(fails: package installation stalled)*

------
https://chatgpt.com/codex/tasks/task_b_68c12a781b5c832e8cfe739c9eda1a49