### PR TITLE
Add thumbnail visuals for cards

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -200,6 +200,20 @@ body {
 .thumb,
 .svc-thumb {
   width: 100%;
+  display: block;
+}
+
+.thumb {
+  background: var(--thumb-bg, linear-gradient(135deg, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.02)));
+}
+
+.svc-thumb {
+  background: var(--svc-thumb, linear-gradient(135deg, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.02)));
+}
+
+.thumb img,
+.svc-thumb img {
+  width: 100%;
   height: auto;
   display: block;
 }

--- a/index.html
+++ b/index.html
@@ -121,19 +121,25 @@
         </div>
         <div class="grid grid-3">
           <article class="card">
-            <div class="thumb" aria-hidden="true"></div>
+            <div class="thumb">
+              <img src="assets/img/gallery/g2.svg" width="1200" height="900" alt="Case-bound art book" loading="lazy" decoding="async" />
+            </div>
             <h3>Case-bound art book</h3>
             <p>Premium boards, Smyth-sewn, foil details.</p>
             <a class="btn with-arrow" href="gallery.html">View project <span class="arrow">&rarr;</span></a>
           </article>
           <article class="card">
-            <div class="thumb" aria-hidden="true"></div>
+            <div class="thumb">
+              <img src="assets/img/gallery/g5.svg" width="1200" height="900" alt="Rigid presentation box" loading="lazy" decoding="async" />
+            </div>
             <h3>Rigid presentation box</h3>
             <p>Custom insert, wrapped, magnetic closure.</p>
             <a class="btn with-arrow" href="gallery.html">View project <span class="arrow">&rarr;</span></a>
           </article>
           <article class="card">
-            <div class="thumb" aria-hidden="true"></div>
+            <div class="thumb">
+              <img src="assets/img/gallery/g3.svg" width="1200" height="900" alt="Children's board book" loading="lazy" decoding="async" />
+            </div>
             <h3>Children's board book</h3>
             <p>Rounded corners, durable safe finishes.</p>
             <a class="btn with-arrow" href="gallery.html">View project <span class="arrow">&rarr;</span></a>


### PR DESCRIPTION
## Summary
- add gradient-aware styling for `.thumb` and `.svc-thumb`
- include representative gallery thumbnails on the homepage

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c148cf70f8832ea7109cbd155ba604